### PR TITLE
 Prevent blowing up the callstack

### DIFF
--- a/app/Main.elm
+++ b/app/Main.elm
@@ -272,70 +272,61 @@ updateModel model =
             |> Computing.tryMakeComputingModule
 
 
+type alias Simulations =
+    { pasteisSimulation : Float
+    , doughCostSimulation : Float
+    }
+
+
 applyTime : Model -> Time -> Model
 applyTime model time =
-    case model.lastTick of
-        Nothing ->
-            let
-                seed0 =
-                    Random.initialSeed (floor (Time.inMilliseconds time))
+    let
+        setLastTick : Model -> Time -> Model
+        setLastTick model time =
+            { model | lastTick = Just time }
 
-                ( float1, seed1 ) =
-                    Utils.randomFloat 0 100 seed0
+        seed0 =
+            Random.initialSeed (floor (Time.inMilliseconds time))
 
-                ( float2, seed2 ) =
-                    Utils.randomFloat 0 100 seed1
-            in
-                applyTime_ model ( [ float1 ], [ float2 ] ) |> flip setLastTick time
+        operationsToRun =
+            case model.lastTick of
+                Nothing ->
+                    1
 
-        Just lastTick ->
-            let
-                elapsedTime =
-                    (Time.inMilliseconds time) - (Time.inMilliseconds lastTick)
+                Just lastTick ->
+                    let
+                        elapsedTime =
+                            (Time.inMilliseconds time) - (Time.inMilliseconds lastTick)
+                    in
+                        Basics.max (floor (elapsedTime / 100)) 1
 
-                operationsToRun =
-                    Basics.min (Basics.max (floor (elapsedTime / 100)) 1) 600
+        ( pasteisSimulations, seed1 ) =
+            Utils.randomMultipleFloat 0 100 operationsToRun seed0
 
-                seed0 =
-                    Random.initialSeed (floor (Time.inMilliseconds time))
+        ( doughCostSimulations, seed2 ) =
+            Utils.randomMultipleFloat 0 100 operationsToRun seed1
 
-                ( floatList1, seed1 ) =
-                    Utils.randomMultipleFloat 0 100 operationsToRun seed0
+        updatedModel =
+            setLastTick model time
 
-                ( floatList2, seed2 ) =
-                    Utils.randomMultipleFloat 0 100 operationsToRun seed1
-            in
-                applyTime_ model ( floatList1, floatList1 ) |> flip setLastTick time
+        allSimulations =
+            List.map2 Simulations pasteisSimulations doughCostSimulations
+
+        reducer simulations model =
+            applyTime_ model simulations
+    in
+        List.foldl reducer updatedModel allSimulations
 
 
-applyTime_ : Model -> ( List Float, List Float ) -> Model
-applyTime_ model ( floatList, floatList2 ) =
-    case List.length floatList of
-        0 ->
-            model
-
-        _ ->
-            let
-                float1 =
-                    Maybe.withDefault 0 (List.head floatList)
-
-                float2 =
-                    Maybe.withDefault 0 (List.head floatList2)
-
-                floats1 =
-                    Maybe.withDefault [] (List.tail floatList)
-
-                floats2 =
-                    Maybe.withDefault [] (List.tail floatList2)
-            in
-                { model
-                    | businessModule = Business.sellPasteis model.businessModule float1
-                    , manufacturingModule = Manufacturing.adjustdoughCost model.manufacturingModule float2
-                }
-                    |> Manufacturing.makePasteis
-                    |> makeOperations
-                    |> updateModel
-                    |> flip applyTime_ ( floats1, floats2 )
+applyTime_ : Model -> Simulations -> Model
+applyTime_ model { pasteisSimulation, doughCostSimulation } =
+    { model
+        | businessModule = Business.sellPasteis model.businessModule pasteisSimulation
+        , manufacturingModule = Manufacturing.adjustdoughCost model.manufacturingModule doughCostSimulation
+    }
+        |> Manufacturing.makePasteis
+        |> makeOperations
+        |> updateModel
 
 
 makeOperations : Model -> Model
@@ -346,8 +337,3 @@ makeOperations model =
 
         Just mod ->
             { model | computingModule = Just (Computing.makeOperations mod) }
-
-
-setLastTick : Model -> Time -> Model
-setLastTick model time =
-    { model | lastTick = Just time }

--- a/app/Main.elm
+++ b/app/Main.elm
@@ -300,22 +300,24 @@ applyTime model time =
                     )
                 |> Maybe.withDefault 1
 
-        ( pasteisSimulations, seed1 ) =
-            Utils.randomMultipleFloat 0 100 operationsToRun seed0
+        step : Int -> ( Model, Random.Seed ) -> ( Model, Random.Seed )
+        step it ( model, seed ) =
+            let
+                ( pasteisSimulation, seed1 ) =
+                    Utils.randomFloat 0 100 seed
 
-        ( doughCostSimulations, seed2 ) =
-            Utils.randomMultipleFloat 0 100 operationsToRun seed1
+                ( doughCostSimulation, seed2 ) =
+                    Utils.randomFloat 0 100 seed1
+            in
+                ( applyTime_ model (Simulations pasteisSimulation doughCostSimulation), seed2 )
 
-        updatedModel =
-            setLastTick model time
-
-        allSimulations =
-            List.map2 Simulations pasteisSimulations doughCostSimulations
-
-        reducer simulations model =
-            applyTime_ model simulations
+        range =
+            List.range 1 operationsToRun
     in
-        List.foldl reducer updatedModel allSimulations
+        setLastTick model time
+            |> \updatedModel ->
+                List.foldl step ( updatedModel, seed0 ) range
+                    |> Tuple.first
 
 
 applyTime_ : Model -> Simulations -> Model

--- a/app/Main.elm
+++ b/app/Main.elm
@@ -289,16 +289,16 @@ applyTime model time =
             Random.initialSeed (floor (Time.inMilliseconds time))
 
         operationsToRun =
-            case model.lastTick of
-                Nothing ->
-                    1
-
-                Just lastTick ->
-                    let
-                        elapsedTime =
-                            (Time.inMilliseconds time) - (Time.inMilliseconds lastTick)
-                    in
-                        Basics.max (floor (elapsedTime / 100)) 1
+            model.lastTick
+                |> Maybe.andThen
+                    (\lastTick ->
+                        let
+                            elapsedTime =
+                                (Time.inMilliseconds time) - (Time.inMilliseconds lastTick)
+                        in
+                            Just <| Basics.max (floor (elapsedTime / 100)) 1
+                    )
+                |> Maybe.withDefault 1
 
         ( pasteisSimulations, seed1 ) =
             Utils.randomMultipleFloat 0 100 operationsToRun seed0
@@ -331,9 +331,8 @@ applyTime_ model { pasteisSimulation, doughCostSimulation } =
 
 makeOperations : Model -> Model
 makeOperations model =
-    case model.computingModule of
-        Nothing ->
-            model
-
-        Just mod ->
-            { model | computingModule = Just (Computing.makeOperations mod) }
+    { model
+        | computingModule =
+            model.computingModule
+                |> Maybe.map Computing.makeOperations
+    }


### PR DESCRIPTION


    This commit transforms the code such that, in the event of receiving a
    tick far ahead of time from the last tick, the callstack does not blow
    up with a `RangeError`.

    One problem was located in `applyTime_`, which was recursively calling
    itself.  While this is supposed to work without any problem, that call
    was not tail-call optimized by the compiler and was essentially a time
    bomb.

    The solution that was applied to correct this issue was to extract the
    simulations (both computation and storage) to the top-level `applyTime`
    function, and (left-)fold over that list to apply transformations
    successively.

    One quick win was to encapsulates each single simulation (a tuple
    composed of the pasteis simulation and the dought cost simultion) in a
    single type.

        +type alias Simulations =
        +    { pasteisSimulation : Float
        +    , doughCostSimulation : Float
        +    }

    So building a list of Simulations data structures was essentially a
    matter of applying `map2` with that Simulation constructor (function
    that has a signature : Float -> Float -> Simulations).